### PR TITLE
Add Xray core update automation for Marzban nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endef
 .PHONY: help deps lint ping deploy update-only deploy-no-update list-tasks \
         haproxy nginx proxy-only \
         script-all script-update-only script-docker-only script-register-only \
-        node-logs
+        node-logs xray-update
 
 help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z0-9_.-]+:.*?## / {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -160,13 +160,23 @@ proxy-with-tls: ## tls_sync + haproxy + nginx (proxy layer with real cert)
 		$(EXTRA)
 
 proxy-check: ## Check haproxy/nginx configs, services, ports, SNI
-	$(LOAD_ENV)
-	@host="$${LIMIT:?Set LIMIT=<host> or group}"; \
-	ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'haproxy -c -f /etc/haproxy/haproxy.cfg'
-	ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'nginx -t'
-	ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'systemctl is-active haproxy; systemctl is-active nginx'
-	ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'ss -lntp | egrep ":443|:1936|:8443|:8444" || true'
-	ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'curl -ks --resolve site.digitalstreamers.xyz:443:127.0.0.1 https://site.digitalstreamers.xyz/ | head -1'
+        $(LOAD_ENV)
+        @host="$${LIMIT:?Set LIMIT=<host> or group}"; \
+        ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'haproxy -c -f /etc/haproxy/haproxy.cfg'
+        ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'nginx -t'
+        ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'systemctl is-active haproxy; systemctl is-active nginx'
+        ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'ss -lntp | egrep ":443|:1936|:8443|:8444" || true'
+        ansible -i "$${INV:-$(INV)}" $$host -m shell -a 'curl -ks --resolve site.digitalstreamers.xyz:443:127.0.0.1 https://site.digitalstreamers.xyz/ | head -1'
+
+xray-update: ## Update Xray core on marzban-node container (use LIMIT=<host>, optional XRAY_VERSION=v...)
+        $(LOAD_ENV)
+        : $${LIMIT:?Set LIMIT=<inventory host>}
+        version="$${XRAY_VERSION:-v25.8.3}"
+        $(ANSIBLE) -i "$${INV:-$(INV)}" "$(PLAY)" \
+                --tags xray_update \
+                --limit "$$LIMIT" \
+                -e xray_core_version="$$version" \
+                $(EXTRA)
 
 # Регистрируем конкретный узел из инвентаря
 # make panel-register LIMIT=nl-ams-3

--- a/ansible/playbooks/provision_node.yml
+++ b/ansible/playbooks/provision_node.yml
@@ -34,6 +34,10 @@
       # пробросим сертификат панели в роль (если panel_api его получал)
       panel_certificate: "{{ hostvars['localhost'].panel_certificate | default('') }}"
 
+    # Обновление ядра Xray внутри контейнера marzban-node
+    - role: xray_core
+      tags: [never, xray_update]
+
     # Прокси-слой
     - { role: haproxy, tags: [haproxy] }
     - { role: nginx, tags: [nginx] }

--- a/ansible/roles/xray_core/defaults/main.yml
+++ b/ansible/roles/xray_core/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# Default Xray core release tag to install. Can be overridden per-host or via extra vars.
+xray_core_version: "v25.8.3"
+
+# Docker container that runs marzban-node and hosts the Xray core binary.
+xray_core_container_name: "marzban-node"
+
+# Force updating the Xray core even if the recorded version matches the desired one.
+xray_core_force_update: false
+
+# Base URL used to download Xray core releases.
+xray_core_download_base: "https://github.com/XTLS/Xray-core/releases/download"
+
+# Directory on the node used to store state files related to Xray updates.
+xray_core_state_dir: "{{ ssl_dir | default('/var/lib/marzban-node') }}"
+
+# Path to the file that keeps track of the last installed Xray version.
+xray_core_version_state_file: "{{ xray_core_state_dir.rstrip('/') }}/.xray-core-version"

--- a/ansible/roles/xray_core/tasks/main.yml
+++ b/ansible/roles/xray_core/tasks/main.yml
@@ -1,0 +1,142 @@
+---
+- name: Gather marzban-node container info
+  community.docker.docker_container_info:
+    name: "{{ xray_core_container_name }}"
+  register: xray_core_container_info
+
+- name: Ensure marzban-node container exists
+  ansible.builtin.fail:
+    msg: >-
+      Container '{{ xray_core_container_name }}' not found. Deploy the marzban-node role before
+      attempting to update the Xray core.
+  when: not xray_core_container_info.exists
+
+- name: Remember container running state
+  ansible.builtin.set_fact:
+    xray_core_container_was_running: "{{ (xray_core_container_info.container.State.Running | default(false)) | bool }}"
+
+- name: Read recorded Xray core version (if any)
+  ansible.builtin.slurp:
+    src: "{{ xray_core_version_state_file }}"
+  register: xray_core_version_state
+  ignore_errors: true
+
+- name: Set recorded version fact
+  ansible.builtin.set_fact:
+    xray_core_version_recorded: "{{ xray_core_version_state.content | b64decode | trim }}"
+  when: not xray_core_version_state.failed | default(false)
+
+- name: Determine whether Xray core update is required
+  ansible.builtin.set_fact:
+    xray_core_update_required: "{{ ((xray_core_force_update | bool) or ((xray_core_version_recorded | default('')) != xray_core_version)) | bool }}"
+
+- name: Show current Xray core status
+  ansible.builtin.debug:
+    msg: >-
+      Xray core version {{ xray_core_version_recorded | default('unknown') }} is already installed;
+      skipping update.
+  when: not xray_core_update_required | bool
+
+- name: Ensure unzip package present for archive extraction
+  ansible.builtin.package:
+    name: unzip
+    state: present
+  when: xray_core_update_required | bool
+
+- name: Build architecture to release asset map
+  ansible.builtin.set_fact:
+    xray_core_release_map:
+      x86_64: Xray-linux-64.zip
+      amd64: Xray-linux-64.zip
+      aarch64: Xray-linux-arm64-v8a.zip
+      arm64: Xray-linux-arm64-v8a.zip
+  when: xray_core_update_required | bool
+
+- name: Determine Xray release asset for this architecture
+  ansible.builtin.set_fact:
+    xray_core_release_asset: "{{ xray_core_release_map.get(ansible_architecture) }}"
+  when: xray_core_update_required | bool
+
+- name: Ensure architecture is supported
+  ansible.builtin.assert:
+    that: xray_core_release_asset is not none
+    fail_msg: "Unsupported architecture '{{ ansible_architecture }}' for Xray core update"
+  when: xray_core_update_required | bool
+
+- name: Create temporary directory for Xray release
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: xray-core
+  register: xray_core_tmp_dir
+  when: xray_core_update_required | bool
+
+- name: Download Xray release archive
+  ansible.builtin.get_url:
+    url: "{{ xray_core_download_base.rstrip('/') }}/{{ xray_core_version }}/{{ xray_core_release_asset }}"
+    dest: "{{ xray_core_tmp_dir.path }}/{{ xray_core_release_asset }}"
+    mode: "0644"
+    force: true
+  when: xray_core_update_required | bool
+
+- name: Extract Xray release archive
+  ansible.builtin.unarchive:
+    src: "{{ xray_core_tmp_dir.path }}/{{ xray_core_release_asset }}"
+    dest: "{{ xray_core_tmp_dir.path }}"
+    remote_src: true
+  when: xray_core_update_required | bool
+
+- name: Copy Xray binary into container
+  ansible.builtin.command:
+    cmd: "docker cp {{ xray_core_tmp_dir.path }}/xray {{ xray_core_container_name }}:/usr/local/bin/xray"
+  changed_when: true
+  when: xray_core_update_required | bool
+
+- name: Copy geoip database into container
+  ansible.builtin.command:
+    cmd: "docker cp {{ xray_core_tmp_dir.path }}/geoip.dat {{ xray_core_container_name }}:/usr/local/share/xray/geoip.dat"
+  changed_when: true
+  when: xray_core_update_required | bool
+
+- name: Copy geosite database into container
+  ansible.builtin.command:
+    cmd: "docker cp {{ xray_core_tmp_dir.path }}/geosite.dat {{ xray_core_container_name }}:/usr/local/share/xray/geosite.dat"
+  changed_when: true
+  when: xray_core_update_required | bool
+
+- name: Restart marzban-node container to apply new Xray core
+  community.docker.docker_container:
+    name: "{{ xray_core_container_name }}"
+    state: started
+    restart: true
+  when:
+    - xray_core_update_required | bool
+    - xray_core_container_was_running | bool
+
+- name: Ensure Xray binary has execute permissions
+  community.docker.docker_container_exec:
+    container: "{{ xray_core_container_name }}"
+    command: chmod 755 /usr/local/bin/xray
+  when:
+    - xray_core_update_required | bool
+    - xray_core_container_was_running | bool
+  changed_when: false
+
+- name: Ensure directory for Xray state file exists
+  ansible.builtin.file:
+    path: "{{ xray_core_state_dir }}"
+    state: directory
+    mode: "0755"
+  when: xray_core_update_required | bool
+
+- name: Record installed Xray version
+  ansible.builtin.copy:
+    dest: "{{ xray_core_version_state_file }}"
+    content: "{{ xray_core_version }}\n"
+    mode: "0644"
+  when: xray_core_update_required | bool
+
+- name: Remove temporary Xray release directory
+  ansible.builtin.file:
+    path: "{{ xray_core_tmp_dir.path }}"
+    state: absent
+  when: xray_core_update_required | bool


### PR DESCRIPTION
## Summary
- add a dedicated xray_core role that downloads the requested Xray release (default v25.8.3) and injects it into the marzban-node container
- track the installed Xray version on the host and expose the role in the provision play with an xray_update tag for opt-in runs
- provide an xray-update Makefile target to run the update against a limited host while allowing the release tag to be overridden

## Testing
- ansible-playbook -i ansible/inventories/example.ini ansible/playbooks/provision_node.yml --syntax-check *(fails: ansible-playbook not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cab1ea2054832a8d79442fd21de2e5